### PR TITLE
Address timestamp casting issue

### DIFF
--- a/katsdpdisp/data.py
+++ b/katsdpdisp/data.py
@@ -359,7 +359,7 @@ class SignalDisplayStore2(object):
             except ImportError:
                 self.mem_cap = 1024*1024*128
                  # default to 128 megabytes if we cannot determine system memory
-        logger.info("Store will use %d MBytes of system memory." % int(self.mem_cap / (1024*1024)))
+        logger.info("Store will use %.2f MBytes of system memory." % (self.mem_cap / (1024.0*1024.0)))
         self.n_ants = n_ants
         self.center_freqs_mhz = []
          # currently this only gets populated on loading historical data


### PR DESCRIPTION
Address bizarre error:
TypeError: Cannot cast array data from dtype('float64') to dtype('int64') according to the rule 'safe'
2017-03-06 11:28:30.825Z - time_plot.py:948 - WARNING - Exception in RingBufferProcess: Cannot cast array data from dtype('float64') to dtype('int64') according to the rule 'safe'
Traceback (most recent call last):
  File "/home/kat/ve/bin/time_plot.py", line 351, in RingBufferProcess
    ts = datasd.select_timeseriesdata(product=0, start_time=0, end_time=1e100, include_ts=True)[0]#gets all timestamps only
  File "/home/kat/ve/local/lib/python2.7/site-packages/katsdpdisp/data.py", line 2198, in select_timeseriesdata
    rolled_ts = np.roll(self.storage.timeseriests,-roll_point)
  File "/home/kat/ve/local/lib/python2.7/site-packages/numpy/core/numeric.py", line 1386, in roll
    res = a.take(indexes, axis)