### PR TITLE
Add script parameter to override default max_custom_signals

### DIFF
--- a/scripts/time_plot.py
+++ b/scripts/time_plot.py
@@ -3138,7 +3138,7 @@ parser.add_argument("--cbf_channels", dest="cbf_channels", default=None, type=in
 parser.add_argument("--l0_name", dest="l0_name", default="sdp_l0", type=str,
                   help="Set stream name for telstate keys (default=%(default)s)")
 parser.add_argument("--max_custom_signals", dest="max_custom_signals", default=128, type=int,
-                  help="Maximum number of custom signals. NOTE keep in synch with katsdpcontroller/generator.py (default=%(default)s)")
+                  help="Maximum number of custom signals (default=%(default)s).")
 
 (opts, args) = parser.parse_known_args()
 


### PR DESCRIPTION
Tested and ready. The issue is that for loading archived files the max_custom_signals parameter should be increased to include all signals because much of the processing normally done by ingest needs to be done in sdisp when loading a file, and all the signals need to be available for this.