### PR TITLE
Switch to multi-stage build

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -5,3 +5,4 @@ temp
 cover
 doc/_build
 *.egg-info
+Dockerfile

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,24 @@
-FROM sdp-docker-registry.kat.ac.za:5000/docker-base
-
+FROM sdp-docker-registry.kat.ac.za:5000/docker-base-build as build
 MAINTAINER Mattieu de Villiers "mattieu@ska.ac.za"
 
+# Enable Python 2 ve
+ENV PATH="$PATH_PYTHON2" VIRTUAL_ENV="$VIRTUAL_ENV_PYTHON2"
+
 # Install dependencies
-COPY requirements.txt /tmp/install/
+COPY --chown=kat:kat requirements.txt /tmp/install/
 RUN install-requirements.py -d ~/docker-base/base-requirements.txt -r /tmp/install/requirements.txt
 
 # Install the package
-COPY . /tmp/install/katsdpdisp
+COPY --chown=kat:kat . /tmp/install/katsdpdisp
 WORKDIR /tmp/install/katsdpdisp
-RUN python ./setup.py clean && pip install --no-index .
+RUN python ./setup.py clean
+RUN pip install --no-deps .
+RUN pip check
+
+#######################################################################
+
+FROM sdp-docker-registry.kat.ac.za:5000/docker-base-runtime
+MAINTAINER Mattieu de Villiers "mattieu@ska.ac.za"
+
+COPY --from=build --chown=kat:kat /home/kat/ve /home/kat/ve
+ENV PATH="$PATH_PYTHON2" VIRTUAL_ENV="$VIRTUAL_ENV_PYTHON2"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,5 @@
 ansicolors
-pkginfo
 cycler
-Cython
 fakeredis
 funcsigs
 functools32
@@ -10,6 +8,7 @@ futures                 # required by trollius
 guppy==0.1.10
 h5py
 ipaddress
+katversion
 linecache2
 manhole
 matplotlib
@@ -26,7 +25,7 @@ python-dateutil
 pytz
 redis
 six
-spead2==1.5.0
+spead2
 subprocess32
 traceback2
 trollius                # required by spead2
@@ -38,4 +37,3 @@ tornado
 unittest2
 git+ssh://git@github.com/ska-sa/katsdpservices
 git+ssh://git@github.com/ska-sa/katsdptelstate
-git+ssh://git@github.com/ska-sa/katversion


### PR DESCRIPTION
Also unpinned spead2 so that a more up-to-date version is used, and
removed pkginfo and Cython from requirements.txt (no longer needed to
install katversion and h5py respectively).