### PR TITLE
Expands clear command to remove specific signals from displays

### DIFF
--- a/katsdpdisp/html/help.txt
+++ b/katsdpdisp/html/help.txt
@@ -101,6 +101,10 @@ blmx
 [clear]
 Removes percentile collection plots from figures.
 
+clear        - removes all plots from figures
+clear 1h1h   - removes signal 1h1h specifically from figures
+clear h*h    - removes all h autocorrelations from figures
+
 [autohh]
 Adds a percentile collection plot to timeseries and spectrum figures for the collection of signals that includes hh auto correlation products.
 

--- a/katsdpdisp/html/index.html
+++ b/katsdpdisp/html/index.html
@@ -51,6 +51,7 @@
                 <a>centerfreqMHz=</a>
                 <a>centerfreqMHz=1284</a>
                 <a>clear</a>
+                <a>clear 1h1h</a>
                 <a>console clear</a>
                 <a>console on</a>
                 <a>console off</a>


### PR DESCRIPTION
Adds a feature (indirectly requested by Sarah) to remove specific signals from the displays (instead of only allowing the clearing of all signals). 

Already tested.