### PR TITLE
Modernise use of katsdptelstate

### DIFF
--- a/scripts/time_plot.py
+++ b/scripts/time_plot.py
@@ -1844,7 +1844,7 @@ def handle_websock_event(handlerkey,*args):
                     thekey=str(args[1])
                     if (thekey=='obs_params'):
                         cbid=str(telstate['sdp_capture_block_id'])
-                        obs_params_key=telstate.SEPARATOR.join((cbid, 'obs_params'))
+                        obs_params_key=telstate.join(cbid, 'obs_params')
                         obs_params=telstate.get(obs_params_key, {})
                         for obskey,obsvalue in obs_params.iteritems():
                             send_websock_cmd('logconsole("'+obskey+': '+repr(obsvalue)+'",true,true,true)',handlerkey)


### PR DESCRIPTION
Replace use of telstate.SEPARATOR with simpler telstate.join.