### PR TITLE
Lost connections

### DIFF
--- a/katsdpdisp/html/data.js
+++ b/katsdpdisp/html/data.js
@@ -139,7 +139,10 @@ function restore_data()
         }
         timerid=setInterval(updateFigure,1000)
         logconsole('Connection restored',true,false,true)
-    }else
+    }else if (document.hidden)//sleep when page in hidden tab instead of reloading page
+	{
+        timerid=setTimeout(restore_data,1000)
+	}else
     {
         start_data();
         timerid=setTimeout(restore_data,5000)

--- a/scripts/time_plot.py
+++ b/scripts/time_plot.py
@@ -3345,7 +3345,7 @@ def parse_websock_cmd(s, handlerkey):
 def send_websock_data(binarydata, handlerkey):
     try:
         if handlerkey in websockrequest_username:#else skip - connection may have gone midway through a send update
-            await handlerkey.write_message(binarydata,binary=True)
+            handlerkey.write_message(binarydata,binary=True)
     except tornado.websocket.WebSocketClosedError: # connection has gone
         logger.warning("Connection to %s@%s has gone. Closing...", websockrequest_username[handlerkey], handlerkey.request.remote_ip)
         deregister_websockrequest_handler(handlerkey)
@@ -3358,7 +3358,14 @@ def send_websock_cmd(cmd, handlerkey):
     try:
         if handlerkey in websockrequest_username:#else skip - connection may have gone midway through a send update
             frame=u"/*exec_user_cmd*/ function callme(){%s; return;};callme();" % cmd;#ensures that vectors of data is not sent back to server!
-            await handlerkey.write_message(frame)
+            if handlerkey.ws_connection is None or handlerkey.ws_connection.is_closing():
+                logger.warning("Stream closing for %s@%s", websockrequest_username[handlerkey], handlerkey.request.remote_ip)
+                deregister_websockrequest_handler(handlerkey)
+            else:
+                handlerkey.write_message(frame)
+    except tornado.iostream.StreamClosedError:
+        logger.warning("Stream closed for %s@%s", websockrequest_username[handlerkey], handlerkey.request.remote_ip)
+        deregister_websockrequest_handler(handlerkey)
     except tornado.websocket.WebSocketClosedError: # connection has gone
         logger.warning("Connection to %s@%s has gone. Closing...", websockrequest_username[handlerkey], handlerkey.request.remote_ip)
         deregister_websockrequest_handler(handlerkey)
@@ -3368,10 +3375,10 @@ def send_websock_cmd(cmd, handlerkey):
         deregister_websockrequest_handler(handlerkey)
 
 def deregister_websockrequest_handler(handlerkey):
-    if (handlerkey in websockrequest_time):
-        del websockrequest_time[handlerkey]
     if (handlerkey in websockrequest_username):
         del websockrequest_username[handlerkey]
+    if (handlerkey in websockrequest_time):
+        del websockrequest_time[handlerkey]
 
 class MainHandler(tornado.web.RequestHandler):
     def set_default_headers(self):

--- a/scripts/time_plot.py
+++ b/scripts/time_plot.py
@@ -3363,10 +3363,7 @@ def send_websock_cmd(cmd, handlerkey):
                 deregister_websockrequest_handler(handlerkey)
             else:
                 handlerkey.write_message(frame)
-    except tornado.iostream.StreamClosedError:
-        logger.warning("Stream closed for %s@%s", websockrequest_username[handlerkey], handlerkey.request.remote_ip)
-        deregister_websockrequest_handler(handlerkey)
-    except tornado.websocket.WebSocketClosedError: # connection has gone
+    except (tornado.websocket.WebSocketClosedError,tornado.iostream.StreamClosedError):
         logger.warning("Connection to %s@%s has gone. Closing...", websockrequest_username[handlerkey], handlerkey.request.remote_ip)
         deregister_websockrequest_handler(handlerkey)
     except Exception as e:

--- a/scripts/time_plot.py
+++ b/scripts/time_plot.py
@@ -3345,7 +3345,7 @@ def parse_websock_cmd(s, handlerkey):
 def send_websock_data(binarydata, handlerkey):
     try:
         if handlerkey in websockrequest_username:#else skip - connection may have gone midway through a send update
-            handlerkey.write_message(binarydata,binary=True)
+            await handlerkey.write_message(binarydata,binary=True)
     except tornado.websocket.WebSocketClosedError: # connection has gone
         logger.warning("Connection to %s@%s has gone. Closing...", websockrequest_username[handlerkey], handlerkey.request.remote_ip)
         deregister_websockrequest_handler(handlerkey)
@@ -3358,7 +3358,7 @@ def send_websock_cmd(cmd, handlerkey):
     try:
         if handlerkey in websockrequest_username:#else skip - connection may have gone midway through a send update
             frame=u"/*exec_user_cmd*/ function callme(){%s; return;};callme();" % cmd;#ensures that vectors of data is not sent back to server!
-            handlerkey.write_message(frame)
+            await handlerkey.write_message(frame)
     except tornado.websocket.WebSocketClosedError: # connection has gone
         logger.warning("Connection to %s@%s has gone. Closing...", websockrequest_username[handlerkey], handlerkey.request.remote_ip)
         deregister_websockrequest_handler(handlerkey)


### PR DESCRIPTION
This PR is in response to the Jira ticket https://skaafrica.atlassian.net/browse/OPS-3455 where a number of error log messages of the kind appeared (unhandled StreamClosedError): 
`2023-02-16 01:58:45.448 [cal6.sdp.mkat.karoo.kat.ac.za](http://mc1.sdp.mkat.karoo.kat.ac.za:5601/app/logtrail) timeplot.sdp_l0: array_1_wide_1  Connection opened...
2023-02-16 01:59:03.181 [cal6.sdp.mkat.karoo.kat.ac.za](http://mc1.sdp.mkat.karoo.kat.ac.za:5601/app/logtrail) timeplot.sdp_l0: array_1_wide_1  Connection to rebaone@10.98.2.1 is closed...
2023-02-16 01:59:03.182 [cal6.sdp.mkat.karoo.kat.ac.za](http://mc1.sdp.mkat.karoo.kat.ac.za:5601/app/logtrail) timeplot.sdp_l0: array_1_wide_1  Task exception was never retrieved
future: <Task finished name='Task-1217484' coro=<WebSocketProtocol13.write_message.<locals>.wrapper() done, defined at /home/kat/ve3/lib/python3.8/site-packages/tornado/websocket.py:1100> exception=WebSocketClosedError()>
Traceback (most recent call last):
  File "/home/kat/ve3/lib/python3.8/site-packages/tornado/websocket.py", line 1102, in wrapper
    await fut
tornado.iostream.StreamClosedError: Stream is closed
During handling of the above exception, another exception occurred:
Traceback (most recent call last):
  File "/home/kat/ve3/lib/python3.8/site-packages/tornado/websocket.py", line 1104, in wrapper
    raise WebSocketClosedError()
tornado.websocket.WebSocketClosedError`

Additionally, the signal displays are often open in hidden tabs of browsers, loosing and opening connections continously. See logs lke:
'
2023-02-16 01:55:45.482 [cal6.sdp.mkat.karoo.kat.ac.za](http://mc1.sdp.mkat.karoo.kat.ac.za:5601/app/logtrail) timeplot.sdp_l0: array_1_wide_1  101 GET /ws (10.98.2.1) 0.42ms
2023-02-16 01:55:45.482 [cal6.sdp.mkat.karoo.kat.ac.za](http://mc1.sdp.mkat.karoo.kat.ac.za:5601/app/logtrail) timeplot.sdp_l0: array_1_wide_1  Connection opened...
2023-02-16 01:55:58.367 [cal6.sdp.mkat.karoo.kat.ac.za](http://mc1.sdp.mkat.karoo.kat.ac.za:5601/app/logtrail) timeplot.sdp_l0: array_1_wide_1  ('setusername', 'rebaone')
2023-02-16 01:56:12.151 [cal6.sdp.mkat.karoo.kat.ac.za](http://mc1.sdp.mkat.karoo.kat.ac.za:5601/app/logtrail) timeplot.sdp_l0: array_1_wide_1  ('load', 'default2')
2023-02-16 01:56:35.685 [cal6.sdp.mkat.karoo.kat.ac.za](http://mc1.sdp.mkat.karoo.kat.ac.za:5601/app/logtrail) timeplot.sdp_l0: array_1_wide_1  Connection to (unknown)@10.98.2.1 is closed...
2023-02-16 01:56:45.438 [cal6.sdp.mkat.karoo.kat.ac.za](http://mc1.sdp.mkat.karoo.kat.ac.za:5601/app/logtrail) timeplot.sdp_l0: array_1_wide_1  101 GET /ws (10.98.2.1) 0.77ms
2023-02-16 01:56:45.438 [cal6.sdp.mkat.karoo.kat.ac.za](http://mc1.sdp.mkat.karoo.kat.ac.za:5601/app/logtrail) timeplot.sdp_l0: array_1_wide_1  Connection opened...
2023-02-16 01:57:29.883 [cal6.sdp.mkat.karoo.kat.ac.za](http://mc1.sdp.mkat.karoo.kat.ac.za:5601/app/logtrail) timeplot.sdp_l0: array_1_wide_1  Connection to rebaone@10.98.2.1 is closed...
2023-02-16 01:57:29.915 [cal6.sdp.mkat.karoo.kat.ac.za](http://mc1.sdp.mkat.karoo.kat.ac.za:5601/app/logtrail) timeplot.sdp_l0: array_1_wide_1  101 GET /ws (10.98.2.1) 1.08ms
2023-02-16 01:57:29.915 [cal6.sdp.mkat.karoo.kat.ac.za](http://mc1.sdp.mkat.karoo.kat.ac.za:5601/app/logtrail) timeplot.sdp_l0: array_1_wide_1  Connection opened...
2023-02-16 01:57:35.439 [cal6.sdp.mkat.karoo.kat.ac.za](http://mc1.sdp.mkat.karoo.kat.ac.za:5601/app/logtrail) timeplot.sdp_l0: array_1_wide_1  Connection to (unknown)@10.98.2.1 is closed...
2023-02-16 01:57:35.796 [cal6.sdp.mkat.karoo.kat.ac.za](http://mc1.sdp.mkat.karoo.kat.ac.za:5601/app/logtrail) timeplot.sdp_l0: array_1_wide_1  ('setusername', 'rebaone')
2023-02-16 01:57:46.230 [cal6.sdp.mkat.karoo.kat.ac.za](http://mc1.sdp.mkat.karoo.kat.ac.za:5601/app/logtrail) timeplot.sdp_l0: array_1_wide_1  101 GET /ws (10.98.2.1) 0.55ms
2023-02-16 01:57:46.231 [cal6.sdp.mkat.karoo.kat.ac.za](http://mc1.sdp.mkat.karoo.kat.ac.za:5601/app/logtrail) timeplot.sdp_l0: array_1_wide_1  Connection opened...
2023-02-16 01:58:14.447 [cal6.sdp.mkat.karoo.kat.ac.za](http://mc1.sdp.mkat.karoo.kat.ac.za:5601/app/logtrail) timeplot.sdp_l0: array_1_wide_1  Connection to rebaone@10.98.2.1 is closed...
2023-02-16 01:58:14.488 [cal6.sdp.mkat.karoo.kat.ac.za](http://mc1.sdp.mkat.karoo.kat.ac.za:5601/app/logtrail) timeplot.sdp_l0: array_1_wide_1  101 GET /ws (10.98.2.1) 0.54ms
2023-02-16 01:58:14.489 [cal6.sdp.mkat.karoo.kat.ac.za](http://mc1.sdp.mkat.karoo.kat.ac.za:5601/app/logtrail) timeplot.sdp_l0: array_1_wide_1  Connection opened...
'
This PR 
1)prevents hidden tabs from attempting to re-open connections, and also 
2)catches the 'old' StreamClosedError (in addition to the modern WebSocketClosedError). See sourcecode of tornado/websocket.py/write_message that suggests that older versions of tornado sometimes had StreamClosedError but now it is normalised to WebSocketClosedError in tornado versions greater than 5.0
3)also checks if stream is closed before calling write_message (maybe superfluous)
